### PR TITLE
build: align templates with Commandex Framework 5.0.1

### DIFF
--- a/src/Calabonga.CommandexCommand.Template/Calabonga.CommandexCommand.Template.csproj
+++ b/src/Calabonga.CommandexCommand.Template/Calabonga.CommandexCommand.Template.csproj
@@ -4,14 +4,14 @@
     <!-- The package metadata. Fill in the properties marked as TODO below -->
     <!-- Follow the instructions on https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices -->
     <PackageId>Calabonga.CommandexCommand.Template</PackageId>
-    <PackageVersion>5.0.0</PackageVersion>
+    <PackageVersion>5.0.1</PackageVersion>
     <Title>Calabonga.CommandexCommand.Template</Title>
     <Authors>Calabonga</Authors>
     <Copyright>Calabonga SOFT © 2024-$([System.DateTime]::Now.ToString(yyyy))</Copyright>
     <Description>DialogCommand templated for Commandex Framework</Description>
     <PackageTags>commandex, command, shell, calabonga, template, tools, wpf, framework</PackageTags>
     <PackageProjectUrl>https://github.com/Calabonga/Calabonga.CommandexCommand.Template</PackageProjectUrl>
-    <PackageReleaseNotes>Aligned with Commandex Framework 5.0.0: all three templates now reference Calabonga.Commandex.Engine 5.0.0. Freshly created command still starts at version 1.0.0.</PackageReleaseNotes>
+    <PackageReleaseNotes>Aligned with Commandex Framework 5.0.1: all three templates now reference Calabonga.Commandex.Engine 5.0.1. Freshly created command still starts at version 1.0.0.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
 
     <!-- Keep package type as 'Template' to show the package as a template package on nuget.org and make your template available in dotnet new search.-->

--- a/src/Calabonga.CommandexCommand.Template/content/DialogCommandTemplate/Commandex.DialogCommand.csproj
+++ b/src/Calabonga.CommandexCommand.Template/content/DialogCommandTemplate/Commandex.DialogCommand.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Calabonga.Commandex.Engine" Version="5.0.0" />
+		<PackageReference Include="Calabonga.Commandex.Engine" Version="5.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/src/Calabonga.CommandexCommand.Template/content/WizardCommandTemplate/Commandex.WizardCommand.csproj
+++ b/src/Calabonga.CommandexCommand.Template/content/WizardCommandTemplate/Commandex.WizardCommand.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Calabonga.Commandex.Engine" Version="5.0.0" />
+		<PackageReference Include="Calabonga.Commandex.Engine" Version="5.0.1" />
 	</ItemGroup>
 
 </Project>

--- a/src/Calabonga.CommandexCommand.Template/content/ZoneCommandTemplate/Commandex.ZoneCommand.csproj
+++ b/src/Calabonga.CommandexCommand.Template/content/ZoneCommandTemplate/Commandex.ZoneCommand.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Calabonga.Commandex.Engine" Version="5.0.0" />
+		<PackageReference Include="Calabonga.Commandex.Engine" Version="5.0.1" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
Релизный цикл Framework **5.0.1**.

- `<PackageVersion>` 5.0.0 → 5.0.1
- все три шаблона команд (`Dialog`, `Wizard`, `Zone`) ссылаются на `Calabonga.Commandex.Engine` 5.0.1
- генерируемая команда по-прежнему стартует с `<Version>1.0.0`

## Проверка

- `dotnet pack Calabonga.CommandexCommand.Template.csproj -c Release` → `Calabonga.CommandexCommand.Template.5.0.1.nupkg`, 0 ошибок

🤖 Generated with [Claude Code](https://claude.com/claude-code)